### PR TITLE
Initial population creation

### DIFF
--- a/GeneticDFA/DFAChromosome.cs
+++ b/GeneticDFA/DFAChromosome.cs
@@ -7,11 +7,11 @@ public class DFAChromosome : IChromosome
     public List<DFAState> States { get; } = new List<DFAState>();
     public List<DFAEdge> Edges { get; } = new List<DFAEdge>();
     public List<DFAEdge> NonDeterministicEdges { get; private set; } = new List<DFAEdge>();
-    public DFAState StartState { get; }
+    public DFAState StartState { get; set; }
     public double? Fitness { get; set; }
     public int Size => States.Count + Edges.Count;
-    private int _nextStateID = 0;
-    private int _nextEdgeID = 0;
+    public int NextStateID { get; set; } = 0;
+    public int NextEdgeID { get; set; } = 0;
 
     public DFAChromosome(List<DFAState> states, List<DFAEdge> edges, DFAState startState)
     {
@@ -31,18 +31,18 @@ public class DFAChromosome : IChromosome
         return new DFAChromosome();
     }
 
+    //Move to mutation and crossover
     public void FindAndAssignNonDeterministicEdges()
     {
-        List<DFAEdge> edges = Edges;
         NonDeterministicEdges = new List<DFAEdge>();
 
-        if (edges.Count < 2)
+        if (Edges.Count < 2)
             return;
         
         //Sort the edges so that non-deterministic edges are grouped.
         //Example with edges as (Source, Input, Target):
         //{(A,1,B), (B,0,A), (A,0,B), (A,1,C), (C,0,C), (B,1,C)}->{(A,1,B), (A,1,C), (A,0,B), (B,0,A), (B,1,C), (C,0,C)}
-        edges.Sort(delegate(DFAEdge edge1, DFAEdge edge2)
+        Edges.Sort(delegate(DFAEdge edge1, DFAEdge edge2)
         {
             int areSourcesEqual = edge1.Source.ID.CompareTo(edge2.Source.ID);
             return areSourcesEqual == 0 ? edge1.Input.CompareTo(edge2.Input) : areSourcesEqual;
@@ -51,20 +51,20 @@ public class DFAChromosome : IChromosome
         //Iterate through the edges and check if each edge has same source and input as a neighbor
         //Special cases for the first and last edge to avoid indexing out of range,
         //since they are at the ends of the array and thus only have 1 neighbor
-        if(edges[0].Source.ID == edges[1].Source.ID && edges[0].Input == edges[1].Input)
-            NonDeterministicEdges.Add(edges[0]);
+        if(Edges[0].Source.ID == Edges[1].Source.ID && Edges[0].Input == Edges[1].Input)
+            NonDeterministicEdges.Add(Edges[0]);
         
-        for (int i = 1; i < edges.Count-1; i++)
+        for (int i = 1; i < Edges.Count-1; i++)
         {
-            if ((edges[i].Source.ID == edges[i + 1].Source.ID && edges[i].Input == edges[i + 1].Input) ||
-                (edges[i].Source.ID == edges[i - 1].Source.ID && edges[i].Input == edges[i - 1].Input))
+            if ((Edges[i].Source.ID == Edges[i + 1].Source.ID && Edges[i].Input == Edges[i + 1].Input) ||
+                (Edges[i].Source.ID == Edges[i - 1].Source.ID && Edges[i].Input == Edges[i - 1].Input))
             {
-                NonDeterministicEdges.Add(edges[i]);
+                NonDeterministicEdges.Add(Edges[i]);
             }
         }
 
-        if(edges[^1].Source.ID == edges[^2].Source.ID && edges[^1].Input == edges[^2].Input)
-            NonDeterministicEdges.Add(edges[^1]);
+        if(Edges[^1].Source.ID == Edges[^2].Source.ID && Edges[^1].Input == Edges[^2].Input)
+            NonDeterministicEdges.Add(Edges[^1]);
     }
     
     

--- a/GeneticDFA/DFAChromosome.cs
+++ b/GeneticDFA/DFAChromosome.cs
@@ -30,16 +30,7 @@ public class DFAChromosome : IChromosome
     {
         return new DFAChromosome();
     }
-
-    public void FixUnreachability(List<char> alphabet)
-    {
-        List<DFAState> reachableStates = FindReachableStates();
-
-        if (reachableStates.Count != States.Count)
-        {
-            AddEdgesToUnreachableStates(reachableStates, alphabet);
-        }
-    }
+    
     
     private List<DFAState> FindReachableStates()
     {
@@ -58,19 +49,19 @@ public class DFAChromosome : IChromosome
         return reachableStates;
     }
 
-    private void AddEdgesToUnreachableStates(IList<DFAState> reachableStates, IReadOnlyList<char> alphabet)
+    public void FixUnreachability(List<char> alphabet)
     {
         while (true)
         {
-            List<DFAState> unreachableStates = States.Where(s => !reachableStates.Contains(s)).ToList();
-            if(unreachableStates.Count == 0)
+            List<DFAState> reachableStates = FindReachableStates();
+            if (reachableStates.Count == States.Count)
                 break;
+            List<DFAState> unreachableStates = States.Where(s => !reachableStates.Contains(s)).ToList();
             DFAState source = reachableStates[RandomizationProvider.Current.GetInt(0, reachableStates.Count)];
             char input = alphabet[RandomizationProvider.Current.GetInt(0, alphabet.Count)];
             DFAState target = unreachableStates[RandomizationProvider.Current.GetInt(0, unreachableStates.Count)];
             Edges.Add(new DFAEdge(NextEdgeID, source, target, input));
             NextEdgeID++;
-            reachableStates = FindReachableStates();
         }
     }
 

--- a/GeneticDFA/DFAChromosome.cs
+++ b/GeneticDFA/DFAChromosome.cs
@@ -30,24 +30,6 @@ public class DFAChromosome : IChromosome
     {
         return new DFAChromosome();
     }
-    
-    
-    private List<DFAState> FindReachableStates()
-    {
-        List<DFAState> reachableStates = new List<DFAState> {StartState};
-
-        while (true)
-        {
-            List<DFAEdge> edgesFromReachableStates = Edges.Where(e => reachableStates.Contains(e.Source)).ToList();
-            List<DFAState> newReachableStates = States.Where(s => edgesFromReachableStates.Any(e => e.Target == s)).ToList();
-            newReachableStates.RemoveAll(s => reachableStates.Contains(s));
-            if (newReachableStates.Count == 0)
-                break;
-            reachableStates.AddRange(newReachableStates);
-        }
-
-        return reachableStates;
-    }
 
     //Does not fit in this class, but the method will be used by both Population class and Crossover class
     public void FixUnreachability(List<char> alphabet)
@@ -71,6 +53,24 @@ public class DFAChromosome : IChromosome
         }
     }
 
+    private List<DFAState> FindReachableStates()
+    {
+        List<DFAState> reachableStates = new List<DFAState> {StartState};
+
+        while (true)
+        {
+            List<DFAEdge> edgesFromReachableStates = Edges.Where(e => reachableStates.Contains(e.Source)).ToList();
+            List<DFAState> newReachableStates = States.Where(s => edgesFromReachableStates.Any(e => e.Target == s)).ToList();
+            newReachableStates.RemoveAll(s => reachableStates.Contains(s));
+            if (newReachableStates.Count == 0)
+                break;
+            reachableStates.AddRange(newReachableStates);
+        }
+
+        return reachableStates;
+    }
+    
+    
     //Does not fit in this class, but the method will be used by both Population class and Mutation class
     public void FindAndAssignNonDeterministicEdges()
     {

--- a/GeneticDFA/DFAChromosome.cs
+++ b/GeneticDFA/DFAChromosome.cs
@@ -49,6 +49,7 @@ public class DFAChromosome : IChromosome
         return reachableStates;
     }
 
+    //Does not fit in this class, but the method will be used by both Population class and Crossover class
     public void FixUnreachability(List<char> alphabet)
     {
         while (true)
@@ -57,6 +58,11 @@ public class DFAChromosome : IChromosome
             if (reachableStates.Count == States.Count)
                 break;
             List<DFAState> unreachableStates = States.Where(s => !reachableStates.Contains(s)).ToList();
+            
+            //Note that we do not check whether the edge we are going to add is unique
+            //(contrast to InitializeChromosomeEdges() in DFAPopulation). This is because we know that if a state is
+            //unreachable, that must mean that no reachable state has an outgoing edge to it.
+            //Thus all edges pointing to unreachable states will be unique.
             DFAState source = reachableStates[RandomizationProvider.Current.GetInt(0, reachableStates.Count)];
             char input = alphabet[RandomizationProvider.Current.GetInt(0, alphabet.Count)];
             DFAState target = unreachableStates[RandomizationProvider.Current.GetInt(0, unreachableStates.Count)];
@@ -65,7 +71,7 @@ public class DFAChromosome : IChromosome
         }
     }
 
-    //Move to mutation and crossover
+    //Does not fit in this class, but the method will be used by both Population class and Mutation class
     public void FindAndAssignNonDeterministicEdges()
     {
         NonDeterministicEdges = new List<DFAEdge>();

--- a/GeneticDFA/DFAChromosomeHelper.cs
+++ b/GeneticDFA/DFAChromosomeHelper.cs
@@ -1,0 +1,83 @@
+﻿using GeneticSharp;
+
+namespace GeneticDFA;
+
+public static class DFAChromosomeHelper
+{
+    //Does not fit in this class, but the method will be used by both Population class and Crossover class
+    public static void FixUnreachability(DFAChromosome chromosome, List<char> alphabet)
+    {
+        while (true)
+        {
+            List<DFAState> reachableStates = FindReachableStates(chromosome);
+            if (reachableStates.Count == chromosome.States.Count)
+                break;
+            List<DFAState> unreachableStates = chromosome.States.Where(s => !reachableStates.Contains(s)).ToList();
+            
+            //Note that we do not check whether the edge we are going to add is unique
+            //(contrast to InitializeChromosomeEdges() in DFAPopulation). This is because we know that if a state is
+            //unreachable, that must mean that no reachable state has an outgoing edge to it.
+            //Thus all edges pointing to unreachable states will be unique.
+            DFAState source = reachableStates[RandomizationProvider.Current.GetInt(0, reachableStates.Count)];
+            char input = alphabet[RandomizationProvider.Current.GetInt(0, alphabet.Count)];
+            DFAState target = unreachableStates[RandomizationProvider.Current.GetInt(0, unreachableStates.Count)];
+            chromosome.Edges.Add(new DFAEdge(chromosome.NextEdgeID, source, target, input));
+            chromosome.NextEdgeID++;
+        }
+    }
+    
+    private static List<DFAState> FindReachableStates(DFAChromosome chromosome)
+    {
+        List<DFAState> reachableStates = new List<DFAState> {chromosome.StartState};
+
+        while (true)
+        {
+            List<DFAEdge> edgesFromReachableStates = chromosome.Edges.Where(e => reachableStates.Contains(e.Source)).ToList();
+            List<DFAState> newReachableStates = chromosome.States.Where(s => edgesFromReachableStates.Any(e => e.Target == s)).ToList();
+            newReachableStates.RemoveAll(s => reachableStates.Contains(s));
+            if (newReachableStates.Count == 0)
+                break;
+            reachableStates.AddRange(newReachableStates);
+        }
+
+        return reachableStates;
+    }
+    
+    //Does not fit in this class, but the method will be used by both Population class and Mutation class
+    public static void FindAndAssignNonDeterministicEdges(DFAChromosome chromosome)
+    {
+        chromosome.NonDeterministicEdges = new List<DFAEdge>();
+
+        if (chromosome.Edges.Count < 2)
+            return;
+        
+        //Sort the edges so that non-deterministic edges are grouped.
+        //Example with edges as (Source, Input, Target):
+        //{(A,1,B), (B,0,A), (A,0,B), (A,1,C), (C,0,C), (B,1,C)}->{(A,1,B), (A,1,C), (A,0,B), (B,0,A), (B,1,C), (C,0,C)}
+        chromosome.Edges.Sort(delegate(DFAEdge edge1, DFAEdge edge2)
+        {
+            int areSourcesEqual = edge1.Source.ID.CompareTo(edge2.Source.ID);
+            return areSourcesEqual == 0 ? edge1.Input.CompareTo(edge2.Input) : areSourcesEqual;
+        });
+
+        //Iterate through the edges and check if each edge has same source and input as a neighbor
+        //Special cases for the first and last edge to avoid indexing out of range,
+        //since they are at the ends of the array and thus only have 1 neighbor
+        if(chromosome.Edges[0].Source.ID == chromosome.Edges[1].Source.ID && chromosome.Edges[0].Input == chromosome.Edges[1].Input)
+            chromosome.NonDeterministicEdges.Add(chromosome.Edges[0]);
+        
+        for (int i = 1; i < chromosome.Edges.Count-1; i++)
+        {
+            if ((chromosome.Edges[i].Source.ID == chromosome.Edges[i + 1].Source.ID && chromosome.Edges[i].Input == chromosome.Edges[i + 1].Input) ||
+                (chromosome.Edges[i].Source.ID == chromosome.Edges[i - 1].Source.ID && chromosome.Edges[i].Input == chromosome.Edges[i - 1].Input))
+            {
+                chromosome.NonDeterministicEdges.Add(chromosome.Edges[i]);
+            }
+        }
+
+        if(chromosome.Edges[^1].Source.ID == chromosome.Edges[^2].Source.ID && chromosome.Edges[^1].Input == chromosome.Edges[^2].Input)
+            chromosome.NonDeterministicEdges.Add(chromosome.Edges[^1]);
+    }
+    
+    
+}

--- a/GeneticDFA/DFAFitness.cs
+++ b/GeneticDFA/DFAFitness.cs
@@ -63,7 +63,7 @@ public class DFAFitness : IFitness
         }
         
         //THIS CALL SHOULD BE MOVED TO THE END OF MUTATION AND CROSSOVERS!
-        chromosome.FindAndAssignNonDeterministicEdges();
+        DFAChromosomeHelper.FindAndAssignNonDeterministicEdges(chromosome);
 
         return fitnessScore - WeightNonDeterministicEdges*chromosome.NonDeterministicEdges.Count - 
                WeightMissingDeterministicEdges*NumberOfMissingDeterministicEdges(chromosome) -

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -68,7 +68,7 @@ public class DFAPopulation : Population
                 e => e.Target != s)).ToList();
             DFAState target = possibleTargets[_rnd.GetInt(0, possibleTargets.Count)];
             
-            edges.Add(new DFAEdge(chromosome.NextEdgeID,source, target, input));
+            edges.Add(new DFAEdge(chromosome.NextEdgeID, source, target, input));
             chromosome.NextEdgeID++;
             uniqueEdgesAdded++;
         }

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -79,6 +79,7 @@ public class DFAPopulation : Population
             uniqueEdgesAdded++;
         }
 
+        //Add reachability check
         chromosome.Edges.AddRange(edges);
         
         

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using GeneticSharp;
+﻿using GeneticSharp;
 
 namespace GeneticDFA;
 
@@ -18,8 +17,6 @@ public class DFAPopulation : Population
         Generations = new List<Generation>();
         GenerationsNumber = 0;
         List<IChromosome> chromosomes = new List<IChromosome>();
-        Stopwatch stopWatch = new Stopwatch();
-        stopWatch.Start();
         for (int index = 0; index < MinSize; ++index)
         {
             DFAChromosome chromosome = (DFAChromosome) AdamChromosome.CreateNew();
@@ -30,13 +27,6 @@ public class DFAPopulation : Population
             chromosome.FindAndAssignNonDeterministicEdges();
             chromosomes.Add(chromosome);
         }
-        stopWatch.Stop();
-        // Get the elapsed time as a TimeSpan value.
-        TimeSpan ts = stopWatch.Elapsed;
-
-        // Format and display the TimeSpan value.
-        int elapsedTime = ts.Milliseconds;
-        Console.WriteLine("RunTime " + elapsedTime);
         CreateNewGeneration(chromosomes);
     }
 

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -24,7 +24,7 @@ public class DFAPopulation : Population
                 throw new InvalidOperationException("Adam chromosome's 'CreateNew' method created a null chromosome.");
             InitializeChromosomeStates(chromosome);
             InitializeChromosomeEdges(chromosome);
-            chromosome.FindAndAssignNonDeterministicEdges();
+            DFAChromosomeHelper.FindAndAssignNonDeterministicEdges(chromosome);
             chromosomes.Add(chromosome);
         }
         CreateNewGeneration(chromosomes);
@@ -32,8 +32,8 @@ public class DFAPopulation : Population
 
     private void InitializeChromosomeStates(DFAChromosome chromosome)
     {
-        //Recall that there should be at least 1 accept state
-        //Also note that the max value parameter of GetInt() is not included in the range of possible values
+        //There should be at least 1 accept state
+        //Note that the max value parameter of GetInt() is not included in the range of possible values
         int numberOfAcceptStates = _rnd.GetInt(1, Alphabet.Count+1);
         for (int i = 0; i < numberOfAcceptStates; i++)
         {
@@ -88,7 +88,7 @@ public class DFAPopulation : Population
         }
 
         chromosome.Edges.AddRange(edges);
-        chromosome.FixUnreachability(Alphabet);
+        DFAChromosomeHelper.FixUnreachability(chromosome, Alphabet);
     }
 
 

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -46,8 +46,16 @@ public class DFAPopulation : Population
             chromosome.NextStateID++;
         }
 
-        //The following causes the start state to not always be the first state in the list,
-        //but that property is not upheld anyways due to the state merge mutation operator
+        /*The following causes the start state to not always be the first state in the list,
+        but that property is not upheld anyways due to the state merge mutation operator
+        This approach is faster than the opposite. I.e. first assigning the start state to the first state,
+        and then iterating through the list of states and assigning accept states based on randomness.
+        That would cause possible reiteration.
+        Furthermore, there would be bias towards making the start state an accept state,
+        since the iteration of the states would start with the first element.
+        The actual implementation ensures that there is no bias, and it is also faster than the aforementioned approach,
+        since we do not have possible reiteration.
+        The downside is readability, since the start state is not always the first state.*/
         int startStateIndex = _rnd.GetInt(0, chromosome.States.Count);
         chromosome.StartState = chromosome.States[startStateIndex];
     }

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -44,8 +44,8 @@ public class DFAPopulation : Population
             chromosome.NextStateID++;
         }
 
-        int startStateID = RandomizationProvider.Current.GetInt(0, chromosome.States.Count-1);
-        chromosome.StartState = chromosome.States.First(s => s.ID == startStateID);
+        int startStateIndex = RandomizationProvider.Current.GetInt(0, chromosome.States.Count-1);
+        chromosome.StartState = chromosome.States[startStateIndex];
         
         
         

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -64,7 +64,8 @@ public class DFAPopulation : Population
             List<DFAEdge> existingEdgesWithCurrentSourceAndInput =
                 existingEdgesWithCurrentSource.Where(e => e.Input == input).ToList();
 
-            List<DFAState> possibleTargets = chromosome.States.Where(s => existingEdgesWithCurrentSourceAndInput.All(e => e.Target != s)).ToList();
+            List<DFAState> possibleTargets = chromosome.States.Where(s => existingEdgesWithCurrentSourceAndInput.All(
+                e => e.Target != s)).ToList();
             DFAState target = possibleTargets[_rnd.GetInt(0, possibleTargets.Count)];
             
             edges.Add(new DFAEdge(chromosome.NextEdgeID,source, target, input));

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -1,4 +1,5 @@
-﻿using GeneticSharp;
+﻿using System.Diagnostics;
+using GeneticSharp;
 
 namespace GeneticDFA;
 
@@ -17,6 +18,8 @@ public class DFAPopulation : Population
         Generations = new List<Generation>();
         GenerationsNumber = 0;
         List<IChromosome> chromosomes = new List<IChromosome>();
+        Stopwatch stopWatch = new Stopwatch();
+        stopWatch.Start();
         for (int index = 0; index < MinSize; ++index)
         {
             DFAChromosome chromosome = (DFAChromosome) AdamChromosome.CreateNew();
@@ -27,6 +30,13 @@ public class DFAPopulation : Population
             chromosome.FindAndAssignNonDeterministicEdges();
             chromosomes.Add(chromosome);
         }
+        stopWatch.Stop();
+        // Get the elapsed time as a TimeSpan value.
+        TimeSpan ts = stopWatch.Elapsed;
+
+        // Format and display the TimeSpan value.
+        int elapsedTime = ts.Milliseconds;
+        Console.WriteLine("RunTime " + elapsedTime);
         CreateNewGeneration(chromosomes);
     }
 

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -1,0 +1,67 @@
+﻿using GeneticSharp;
+
+namespace GeneticDFA;
+
+public class DFAPopulation : Population
+{
+    public DFAPopulation(int minSize, int maxSize, IChromosome adamChromosome, List<char> alphabet) : base(minSize, maxSize, adamChromosome)
+    {
+        Alphabet = alphabet;
+    }
+
+    public List<char> Alphabet { get; }
+
+    public override void CreateInitialGeneration()
+    {
+        Generations = new List<Generation>();
+        GenerationsNumber = 0;
+        List<IChromosome> chromosomes = new List<IChromosome>();
+        for (int index = 0; index < MinSize; ++index)
+        {
+            IChromosome chromosome = AdamChromosome.CreateNew();
+            if (chromosome == null)
+                throw new InvalidOperationException("Adam chromosome's 'CreateNew' method created a null chromosome.");
+            InitializeChromosome(chromosome);
+            chromosomes.Add(chromosome);
+        }
+        CreateNewGeneration(chromosomes);
+        
+        
+    }
+
+    private void InitializeChromosome(IChromosome paramChromosome)
+    {
+        DFAChromosome chromosome = (DFAChromosome) paramChromosome;
+        int numberOfAcceptStates = RandomizationProvider.Current.GetInt(1, Alphabet.Count);
+        for (int i = 0; i < numberOfAcceptStates; i++)
+        {
+            chromosome.States.Add(new DFAState(chromosome.NextStateID, true));
+            chromosome.NextStateID++;
+        }
+        for (int i = numberOfAcceptStates; i < Alphabet.Count; i++)
+        {
+            chromosome.States.Add(new DFAState(chromosome.NextStateID, false));
+            chromosome.NextStateID++;
+        }
+
+        int startStateID = RandomizationProvider.Current.GetInt(0, chromosome.States.Count-1);
+        chromosome.StartState = chromosome.States.First(s => s.ID == startStateID);
+        
+        
+        
+        
+    }
+    
+    //Copied from source code, but without gene validation, since we do not use the gene properties on chromosomes
+    public override void CreateNewGeneration(IList<IChromosome> chromosomes)
+    {
+        ExceptionHelper.ThrowIfNull(nameof (chromosomes), chromosomes);
+        chromosomes.ValidateGenes();
+        CurrentGeneration = new Generation(++GenerationsNumber, chromosomes);
+        Generations.Add(CurrentGeneration);
+        GenerationStrategy.RegisterNewGeneration( this);
+    }
+    
+    
+    
+}

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -19,10 +19,11 @@ public class DFAPopulation : Population
         List<IChromosome> chromosomes = new List<IChromosome>();
         for (int index = 0; index < MinSize; ++index)
         {
-            IChromosome chromosome = AdamChromosome.CreateNew();
+            DFAChromosome chromosome = (DFAChromosome) AdamChromosome.CreateNew();
             if (chromosome == null)
                 throw new InvalidOperationException("Adam chromosome's 'CreateNew' method created a null chromosome.");
             InitializeChromosome(chromosome);
+            chromosome.FindAndAssignNonDeterministicEdges();
             chromosomes.Add(chromosome);
         }
         CreateNewGeneration(chromosomes);
@@ -30,9 +31,14 @@ public class DFAPopulation : Population
         
     }
 
-    private void InitializeChromosome(IChromosome paramChromosome)
+    private void InitializeChromosome(DFAChromosome chromosome)
     {
-        DFAChromosome chromosome = (DFAChromosome) paramChromosome;
+        InitializeChromosomeStates(chromosome);
+        InitializeChromosomeEdges(chromosome);
+    }
+
+    private void InitializeChromosomeStates(DFAChromosome chromosome)
+    {
         int numberOfAcceptStates = _rnd.GetInt(1, Alphabet.Count+1);
         for (int i = 0; i < numberOfAcceptStates; i++)
         {
@@ -47,7 +53,10 @@ public class DFAPopulation : Population
 
         int startStateIndex = _rnd.GetInt(0, chromosome.States.Count);
         chromosome.StartState = chromosome.States[startStateIndex];
+    }
 
+    private void InitializeChromosomeEdges(DFAChromosome chromosome)
+    {
         List<DFAEdge> edges = new List<DFAEdge>();
         int edgesToAdd = (int) Math.Pow(Alphabet.Count, 2);
         int uniqueEdgesAdded = 0;
@@ -71,9 +80,11 @@ public class DFAPopulation : Population
         }
 
         chromosome.Edges.AddRange(edges);
-        chromosome.FindAndAssignNonDeterministicEdges();
-
+        
+        
     }
+    
+    
     
     //Copied from source code, but without gene validation, since we do not use the gene properties on chromosomes
     public override void CreateNewGeneration(IList<IChromosome> chromosomes)

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -22,19 +22,12 @@ public class DFAPopulation : Population
             DFAChromosome chromosome = (DFAChromosome) AdamChromosome.CreateNew();
             if (chromosome == null)
                 throw new InvalidOperationException("Adam chromosome's 'CreateNew' method created a null chromosome.");
-            InitializeChromosome(chromosome);
+            InitializeChromosomeStates(chromosome);
+            InitializeChromosomeEdges(chromosome);
             chromosome.FindAndAssignNonDeterministicEdges();
             chromosomes.Add(chromosome);
         }
         CreateNewGeneration(chromosomes);
-        
-        
-    }
-
-    private void InitializeChromosome(DFAChromosome chromosome)
-    {
-        InitializeChromosomeStates(chromosome);
-        InitializeChromosomeEdges(chromosome);
     }
 
     private void InitializeChromosomeStates(DFAChromosome chromosome)

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -32,6 +32,8 @@ public class DFAPopulation : Population
 
     private void InitializeChromosomeStates(DFAChromosome chromosome)
     {
+        //Recall that there should be at least 1 accept state
+        //Also note that the max value parameter of GetInt() is not included in the range of possible values
         int numberOfAcceptStates = _rnd.GetInt(1, Alphabet.Count+1);
         for (int i = 0; i < numberOfAcceptStates; i++)
         {
@@ -44,6 +46,8 @@ public class DFAPopulation : Population
             chromosome.NextStateID++;
         }
 
+        //The following causes the start state to not always be the first state in the list,
+        //but that property is not upheld anyways due to the state merge mutation operator
         int startStateIndex = _rnd.GetInt(0, chromosome.States.Count);
         chromosome.StartState = chromosome.States[startStateIndex];
     }
@@ -53,17 +57,27 @@ public class DFAPopulation : Population
         List<DFAEdge> edges = new List<DFAEdge>();
         int edgesToAdd = (int) Math.Pow(Alphabet.Count, 2);
         int uniqueEdgesAdded = 0;
+        
+        //This loop always terminates. When the alphabet size is x, the chromosome will have x states.
+        //For each state there are x^2 possible edges where that state is the source.
+        //Thus there are x^3 possible unique edges. Since edgesToAdd is x^2, the loop will always terminate.
         while (uniqueEdgesAdded < edgesToAdd)
         {
+            //Note that we do not check whether the source chosen is a valid source (as we do with input and target),
+            //based on the same reasoning as for the loop termination. I.e. each state has x^2 unique edges,
+            //so if the source is not valid, all x^2 of its edges must already be created,
+            //but in that case the loop should have terminated beforehand. 
             DFAState source = chromosome.States[_rnd.GetInt(0, chromosome.States.Count)];
             List<DFAEdge> existingEdgesWithCurrentSource = edges.Where(e => e.Source == source).ToList();
             
+            //Find the inputs that can be used to create a new unique edge with the chosen source
             List<char> possibleInputs = Alphabet.Where(i => existingEdgesWithCurrentSource.Count(
                 e=> e.Input == i) < chromosome.States.Count).ToList();
             char input = possibleInputs[_rnd.GetInt(0, possibleInputs.Count)];
             List<DFAEdge> existingEdgesWithCurrentSourceAndInput =
                 existingEdgesWithCurrentSource.Where(e => e.Input == input).ToList();
 
+            //Find the targets that can be used to create a new unique edge with the chosen source and input
             List<DFAState> possibleTargets = chromosome.States.Where(s => existingEdgesWithCurrentSourceAndInput.All(
                 e => e.Target != s)).ToList();
             DFAState target = possibleTargets[_rnd.GetInt(0, possibleTargets.Count)];

--- a/GeneticDFA/DFAPopulation.cs
+++ b/GeneticDFA/DFAPopulation.cs
@@ -9,7 +9,7 @@ public class DFAPopulation : Population
         Alphabet = alphabet;
     }
 
-    public List<char> Alphabet { get; }
+    private List<char> Alphabet { get; }
     private readonly IRandomization _rnd = RandomizationProvider.Current;
     
     public override void CreateInitialGeneration()
@@ -79,14 +79,11 @@ public class DFAPopulation : Population
             uniqueEdgesAdded++;
         }
 
-        //Add reachability check
         chromosome.Edges.AddRange(edges);
-        
-        
+        chromosome.FixUnreachability(Alphabet);
     }
-    
-    
-    
+
+
     //Copied from source code, but without gene validation, since we do not use the gene properties on chromosomes
     public override void CreateNewGeneration(IList<IChromosome> chromosomes)
     {

--- a/GeneticDFA/Program.cs
+++ b/GeneticDFA/Program.cs
@@ -7,7 +7,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        const int minPopulation = 200;
+        const int minPopulation = 500;
         const int maxPopulation = 800;
         const int convergenceGenerationNumber = 100;
         const int maximumGenerationNumber = 1000;
@@ -34,7 +34,7 @@ class Program
             new TestTrace("1010", false),
             new TestTrace("00000000000111", false),
         };
-        List<char> alphabet = new List<char>() {'1', '0'};
+        List<char> alphabet = new List<char>() {'1', '0', '2'};
         
         EliteSelection selection = new EliteSelection();
         UniformCrossover crossover = new UniformCrossover();

--- a/GeneticDFA/Program.cs
+++ b/GeneticDFA/Program.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using GeneticSharp;
+﻿using GeneticSharp;
 
 namespace GeneticDFA;
 

--- a/GeneticDFA/Program.cs
+++ b/GeneticDFA/Program.cs
@@ -47,7 +47,7 @@ class Program
         // Specific chromosome (gene) function for the DFA learning problem.
         DFAChromosome chromosome = new DFAChromosome();
 
-        Population population = new Population(minPopulation, maxPopulation, chromosome);
+        DFAPopulation population = new DFAPopulation(minPopulation, maxPopulation, chromosome, alphabet);
 
         OrTermination stoppingCriterion = new OrTermination(new GenerationNumberTermination(maximumGenerationNumber),
             new AndTermination(new FitnessStagnationTermination(convergenceGenerationNumber),

--- a/GeneticDFA/Program.cs
+++ b/GeneticDFA/Program.cs
@@ -33,7 +33,7 @@ class Program
             new TestTrace("1010", false),
             new TestTrace("00000000000111", false),
         };
-        List<char> alphabet = new List<char>() {'1', '0', '2', '3', '4', '5'};
+        List<char> alphabet = new List<char>() {'1', '0'};
         
         EliteSelection selection = new EliteSelection();
         UniformCrossover crossover = new UniformCrossover();

--- a/GeneticDFA/Program.cs
+++ b/GeneticDFA/Program.cs
@@ -65,12 +65,12 @@ class Program
 
         // Begin learning.
         Console.WriteLine("GA is learning the DFA...");
-        /*ga.Start();
+        ga.Start();
 
         Console.WriteLine();
         Console.WriteLine($"Best solution found has fitness: {ga.BestChromosome.Fitness}");
         Console.WriteLine($"Elapsed time: {ga.TimeEvolving}");
-        Console.ReadKey();*/
+        Console.ReadKey();
     }
     
 }

--- a/GeneticDFA/Program.cs
+++ b/GeneticDFA/Program.cs
@@ -7,8 +7,8 @@ class Program
 {
     static void Main(string[] args)
     {
-        const int minPopulation = 500;
-        const int maxPopulation = 800;
+        const int minPopulation = 1000;
+        const int maxPopulation = 1000;
         const int convergenceGenerationNumber = 100;
         const int maximumGenerationNumber = 1000;
         const int fitnessLowerBound = 100;
@@ -34,7 +34,7 @@ class Program
             new TestTrace("1010", false),
             new TestTrace("00000000000111", false),
         };
-        List<char> alphabet = new List<char>() {'1', '0', '2'};
+        List<char> alphabet = new List<char>() {'1', '0', '2', '3', '4', '5'};
         
         EliteSelection selection = new EliteSelection();
         UniformCrossover crossover = new UniformCrossover();

--- a/GeneticDFATests/DFAChromosomeTests.cs
+++ b/GeneticDFATests/DFAChromosomeTests.cs
@@ -19,7 +19,7 @@ public class DFAChromosomeTests
         DFAChromosome chromosome = new DFAChromosome(States, edges, State1);
         
         //Act
-        chromosome.FindAndAssignNonDeterministicEdges();
+        DFAChromosomeHelper.FindAndAssignNonDeterministicEdges(chromosome);
 
         //Assert
         Assert.Equal(chromosome.NonDeterministicEdges, expected);
@@ -36,7 +36,7 @@ public class DFAChromosomeTests
         List<DFAEdge> expected = new List<DFAEdge>(edges);
         
         //Act
-        chromosome.FixUnreachability(alphabet);
+        DFAChromosomeHelper.FindAndAssignNonDeterministicEdges(chromosome);
         
         //Assert
         Assert.Equal(expected, chromosome.Edges);
@@ -58,7 +58,7 @@ public class DFAChromosomeTests
         //Act
         foreach (DFAChromosome chromosome in chromosomes)
         {
-            chromosome.FixUnreachability(alphabet);
+            DFAChromosomeHelper.FindAndAssignNonDeterministicEdges(chromosome);
         }
         
         //Assert
@@ -86,7 +86,7 @@ public class DFAChromosomeTests
         //Act
         foreach (DFAChromosome chromosome in chromosomes)
         {
-            chromosome.FixUnreachability(alphabet);
+            DFAChromosomeHelper.FindAndAssignNonDeterministicEdges(chromosome);
         }
         
         //Assert
@@ -107,7 +107,7 @@ public class DFAChromosomeTests
         DFAChromosome chromosome = new DFAChromosome(States, new List<DFAEdge>(edges), State1);
         
         //Act
-        chromosome.FixUnreachability(alphabet);
+        DFAChromosomeHelper.FindAndAssignNonDeterministicEdges(chromosome);
         RandomizationProvider.Current = new FastRandomRandomization();
 
         //Assert

--- a/GeneticDFATests/DFAFitnessTests.cs
+++ b/GeneticDFATests/DFAFitnessTests.cs
@@ -41,7 +41,7 @@ public class DFAFitnessTests
     {
         //Arrange
         DFAFitness fitness = new DFAFitness(new List<TestTrace>(), new List<char>(), 0, 0, 0, 0, 1, 0, 0);
-        chromosome.FindAndAssignNonDeterministicEdges();
+        DFAChromosomeHelper.FindAndAssignNonDeterministicEdges(chromosome);
         
         //Act 
         double actual = fitness.Evaluate(chromosome);
@@ -72,7 +72,7 @@ public class DFAFitnessTests
     {
         //Arrange
         DFAFitness fitness = new DFAFitness(SampleTraces, alphabet, 1, 1, 1, 1, 1, 1, 1);
-        chromosome.FindAndAssignNonDeterministicEdges();
+        DFAChromosomeHelper.FindAndAssignNonDeterministicEdges(chromosome);
         
         //Act 
         double actual = fitness.Evaluate(chromosome);

--- a/GeneticDFATests/DFAPopulationTests.cs
+++ b/GeneticDFATests/DFAPopulationTests.cs
@@ -89,11 +89,10 @@ public class DFAPopulationTests
             DFAChromosome dfaChromosome = (DFAChromosome) c;
             Assert.Equal(expected, dfaChromosome.NextStateID);
         });
-        
     }
     
     [Fact]
-    public void InitialIndividualsHasAtleastOneAcceptState()
+    public void InitialIndividualsHasAtLeastOneAcceptState()
     {
         //Arrange
         DFAChromosome chromosome = new DFAChromosome();
@@ -127,6 +126,91 @@ public class DFAPopulationTests
         {
             DFAChromosome dfaChromosome = (DFAChromosome) c;
             Assert.NotNull(dfaChromosome.StartState);
+        });
+    }
+    
+    [Theory]
+    [InlineData(new []{'0'}, 1)]
+    [InlineData(new []{'0', '1'}, 4)]
+    [InlineData(new []{'0', '1', '2'}, 9)]
+    [InlineData(new []{'0', '1', '2', '3'}, 16)]
+    [InlineData(new []{'0', '1', '2', '3', '4'}, 25)]
+    public void InitialIndividualsHasNumberOfEdgesAtLeastSquareOfAlphabetSize(char[] alphabet, int expectedLowerBound)
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        DFAPopulation population = new DFAPopulation(100, 100, chromosome, alphabet.ToList());
+        
+        //Act
+        population.CreateInitialGeneration();
+        
+        //Assert
+        Assert.All(population.Generations[0].Chromosomes, c =>
+        {
+            DFAChromosome dfaChromosome = (DFAChromosome) c;
+            Assert.True(expectedLowerBound <= dfaChromosome.Edges.Count);
+        });
+    }
+    
+    [Fact]
+    public void InitialIndividualsEdgesHasUniqueID()
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        List<char> alphabet = new List<char>() {'0', '1', '2', '3'};
+        DFAPopulation population = new DFAPopulation(100, 100, chromosome, alphabet);
+        
+        //Act
+        population.CreateInitialGeneration();
+        
+        //Assert
+        Assert.All(population.Generations[0].Chromosomes, c =>
+        {
+            DFAChromosome dfaChromosome = (DFAChromosome) c;
+            Assert.All(dfaChromosome.Edges, e => Assert.Single(dfaChromosome.Edges, e2 => e2.ID == e.ID));
+        });
+    }
+    
+    [Theory]
+    [InlineData(new []{'0'})]
+    [InlineData(new []{'0', '1'})]
+    [InlineData(new []{'0', '1', '2'})]
+    [InlineData(new []{'0', '1', '2', '3'})]
+    [InlineData(new []{'0', '1', '2', '3', '4'})]
+    public void InitialIndividualsNextEdgeIDPropertyIsCorrect(char[] alphabet)
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        DFAPopulation population = new DFAPopulation(100, 100, chromosome, alphabet.ToList());
+        
+        //Act
+        population.CreateInitialGeneration();
+        
+        //Assert
+        Assert.All(population.Generations[0].Chromosomes, c =>
+        {
+            DFAChromosome dfaChromosome = (DFAChromosome) c;
+            Assert.Equal(dfaChromosome.Edges.Count, dfaChromosome.NextEdgeID);
+        });
+    }
+    
+    [Fact]
+    public void InitialIndividualsEdgesAreUnique()
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        List<char> alphabet = new List<char>() {'0', '1', '2', '3'};
+        DFAPopulation population = new DFAPopulation(100, 100, chromosome, alphabet);
+        
+        //Act
+        population.CreateInitialGeneration();
+        
+        //Assert
+        Assert.All(population.Generations[0].Chromosomes, c =>
+        {
+            DFAChromosome dfaChromosome = (DFAChromosome) c;
+            Assert.All(dfaChromosome.Edges, e => Assert.Single(dfaChromosome.Edges, e2 => e2.Source == e.Source && 
+                e2.Input == e.Input && e2.Target == e.Target));
         });
     }
     

--- a/GeneticDFATests/DFAPopulationTests.cs
+++ b/GeneticDFATests/DFAPopulationTests.cs
@@ -1,0 +1,135 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GeneticDFA;
+using Xunit;
+
+namespace GeneticDFATests;
+
+public class DFAPopulationTests
+{
+    [Theory]
+    [InlineData(10, 10, 10)]
+    [InlineData(100, 100, 100)]
+    [InlineData(10, 100, 10)]
+    [InlineData(1000, 1000, 1000)]
+    public void InitialGenerationHasCorrectAmountOfIndividuals(int minSize, int maxSize, int expected)
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        List<char> alphabet = new List<char>() {'0', '1'};
+        DFAPopulation population = new DFAPopulation(minSize, maxSize, chromosome, alphabet);
+        
+        //Act
+        population.CreateInitialGeneration();
+
+        //Assert
+        Assert.Equal(expected, population.Generations[0].Chromosomes.Count);
+    }
+
+    [Theory]
+    [InlineData(new []{'0'}, 1)]
+    [InlineData(new []{'0', '1'}, 2)]
+    [InlineData(new []{'0', '1', '2'}, 3)]
+    [InlineData(new []{'0', '1', '2', '3'}, 4)]
+    [InlineData(new []{'0', '1', '2', '3', '4'}, 5)]
+    public void InitialIndividualsHasNumberOfStatesEqualToAlphabetSize(char[] alphabet, int expected)
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        DFAPopulation population = new DFAPopulation(100, 100, chromosome, alphabet.ToList());
+        
+        //Act
+        population.CreateInitialGeneration();
+        
+        //Assert
+        Assert.All(population.Generations[0].Chromosomes, c =>
+        {
+            DFAChromosome dfaChromosome = (DFAChromosome) c;
+            Assert.Equal(expected, dfaChromosome.States.Count);
+        });
+    }
+
+    [Fact]
+    public void InitialIndividualsStatesHasUniqueID()
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        List<char> alphabet = new List<char>() {'0', '1', '2', '3'};
+        DFAPopulation population = new DFAPopulation(100, 100, chromosome, alphabet);
+        
+        //Act
+        population.CreateInitialGeneration();
+        
+        //Assert
+        Assert.All(population.Generations[0].Chromosomes, c =>
+        {
+            DFAChromosome dfaChromosome = (DFAChromosome) c;
+            Assert.All(dfaChromosome.States, s => Assert.Single(dfaChromosome.States, s2 => s2.ID == s.ID));
+        });
+    }
+
+    [Theory]
+    [InlineData(new []{'0'}, 1)]
+    [InlineData(new []{'0', '1'}, 2)]
+    [InlineData(new []{'0', '1', '2'}, 3)]
+    [InlineData(new []{'0', '1', '2', '3'}, 4)]
+    [InlineData(new []{'0', '1', '2', '3', '4'}, 5)]
+    public void InitialIndividualsNextStateIDPropertyIsCorrect(char[] alphabet, int expected)
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        DFAPopulation population = new DFAPopulation(100, 100, chromosome, alphabet.ToList());
+        
+        //Act
+        population.CreateInitialGeneration();
+        
+        //Assert
+        Assert.All(population.Generations[0].Chromosomes, c =>
+        {
+            DFAChromosome dfaChromosome = (DFAChromosome) c;
+            Assert.Equal(expected, dfaChromosome.NextStateID);
+        });
+        
+    }
+    
+    [Fact]
+    public void InitialIndividualsHasAtleastOneAcceptState()
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        List<char> alphabet = new List<char>() {'0', '1', '2'};
+        DFAPopulation population = new DFAPopulation(100, 100, chromosome, alphabet);
+        
+        //Act
+        population.CreateInitialGeneration();
+        
+        //Assert
+        Assert.All(population.Generations[0].Chromosomes, c =>
+        {
+            DFAChromosome dfaChromosome = (DFAChromosome) c;
+            Assert.Contains(dfaChromosome.States, s => s.IsAccept);
+        });
+    }
+
+    [Fact]
+    public void InitialIndividualsHasStartStateAssigned()
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        List<char> alphabet = new List<char>() {'0', '1', '2'};
+        DFAPopulation population = new DFAPopulation(100, 100, chromosome, alphabet);
+        
+        //Act
+        population.CreateInitialGeneration();
+        
+        //Assert
+        Assert.All(population.Generations[0].Chromosomes, c =>
+        {
+            DFAChromosome dfaChromosome = (DFAChromosome) c;
+            Assert.NotNull(dfaChromosome.StartState);
+        });
+    }
+    
+    
+    
+}

--- a/GeneticDFATests/DFAPopulationTests.cs
+++ b/GeneticDFATests/DFAPopulationTests.cs
@@ -152,6 +152,30 @@ public class DFAPopulationTests
         });
     }
     
+    [Theory]
+    [InlineData(new []{'0'}, 1)]
+    [InlineData(new []{'0', '1'}, 5)]
+    [InlineData(new []{'0', '1', '2'}, 11)]
+    [InlineData(new []{'0', '1', '2', '3'}, 19)]
+    [InlineData(new []{'0', '1', '2', '3', '4'}, 29)]
+    public void InitialIndividualsHasNumberOfEdgesAtMostSquareOfAlphabetSizePlusAlphabetSizeMinusOne(char[] alphabet, int expectedUpperBound)
+    {
+        //Arrange
+        DFAChromosome chromosome = new DFAChromosome();
+        DFAPopulation population = new DFAPopulation(100, 100, chromosome, alphabet.ToList());
+        
+        //Act
+        population.CreateInitialGeneration();
+        
+        //Assert
+        Assert.All(population.Generations[0].Chromosomes, c =>
+        {
+            DFAChromosome dfaChromosome = (DFAChromosome) c;
+            Assert.True(expectedUpperBound >= dfaChromosome.Edges.Count);
+        });
+    }
+    
+    
     [Fact]
     public void InitialIndividualsEdgesHasUniqueID()
     {

--- a/GeneticDFATests/TestRandomization.cs
+++ b/GeneticDFATests/TestRandomization.cs
@@ -1,0 +1,41 @@
+﻿using GeneticSharp;
+
+namespace GeneticDFATests;
+
+public class TestRandomization : IRandomization
+{
+    public int GetInt(int min, int max)
+    {
+        return min;
+    }
+
+    public int[] GetInts(int length, int min, int max)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public int[] GetUniqueInts(int length, int min, int max)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public float GetFloat()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public float GetFloat(float min, float max)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public double GetDouble()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public double GetDouble(double min, double max)
+    {
+        throw new System.NotImplementedException();
+    }
+}


### PR DESCRIPTION
Implemented the initial population creation. Added more functionality to Chromosome class. Both the new functionality and the FindAndAssignNonDetEdges method will be used in both the population class and the mutation/crossover classes, so therefore they cannot simply be moved to one of those classes as we had previously discussed. For now they are in the chromosome class as it is the best fit. We could create a static class that contains these methods.